### PR TITLE
Fix astronomical adjustment

### DIFF
--- a/data_preprocessing/astronomical_adjustment.py
+++ b/data_preprocessing/astronomical_adjustment.py
@@ -69,9 +69,8 @@ class AstronomicalAdjustment:
             float: Returns the hour angle in radians
 
         """
-        hour_angle_degrees = (
-            15 * cls.apparent_solar_time(time, day_number, longitude, utc_off)
-            - 12
+        hour_angle_degrees = 15 * (
+            cls.apparent_solar_time(time, day_number, longitude, utc_off) - 12
         )
         return math.radians(hour_angle_degrees)
 
@@ -114,7 +113,7 @@ class AstronomicalAdjustment:
         """
         D = cls.d_helper(day_number)
         return (
-            9.87 * math.cos(2 * D) - 7.53 * math.cos(D) - 1.5 * math.sin(D)
+            9.87 * math.sin(2 * D) - 7.53 * math.cos(D) - 1.5 * math.sin(D)
         ) / 60
 
     @classmethod

--- a/data_preprocessing/astronomical_adjustment.py
+++ b/data_preprocessing/astronomical_adjustment.py
@@ -53,7 +53,7 @@ class AstronomicalAdjustment:
         """
         EARTH_ANGLE = math.radians(23.45)
         D = cls.d_helper(day_number)
-        return np.arcsin(math.sin(EARTH_ANGLE) * math.sin(D))
+        return math.asin(math.sin(EARTH_ANGLE) * math.sin(D))
 
     @classmethod
     def hour_angle(cls, time, day_number, longitude, utc_off):
@@ -70,7 +70,8 @@ class AstronomicalAdjustment:
 
         """
         hour_angle_degrees = (
-            15 * cls.apparent_solar_time(time, day_number, longitude, utc_off) - 12
+            15 * cls.apparent_solar_time(time, day_number, longitude, utc_off)
+            - 12
         )
         return math.radians(hour_angle_degrees)
 
@@ -112,7 +113,9 @@ class AstronomicalAdjustment:
 
         """
         D = cls.d_helper(day_number)
-        return (9.87 * math.sin(2 * D) - 7.53 * math.cos(D) - 1.5 * math.sin(D)) / 60
+        return (
+            9.87 * math.cos(2 * D) - 7.53 * math.cos(D) - 1.5 * math.sin(D)
+        ) / 60
 
     @classmethod
     def angle_sun_surface(cls, time, day_number, latitude, longitude, utc_off):
@@ -136,7 +139,7 @@ class AstronomicalAdjustment:
         BETA = cls.BETA
         declination_angle = cls.declination_angle(day_number)
         hour_angle = cls.hour_angle(time, day_number, longitude, utc_off)
-        latitude = np.radians(latitude)
+        latitude = abs(math.radians(latitude))
         ret_val = (
             (math.sin(declination_angle) * math.sin(latitude) * math.cos(BETA))
             - (
@@ -199,7 +202,7 @@ class AstronomicalAdjustment:
         """
 
         cumulative_days = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-        return sum(cumulative_days[0 : int(month - 1)]) + day
+        return sum(cumulative_days[0 : int(month)]) + day
 
     @classmethod
     def effective_solar_radiance(
@@ -229,5 +232,7 @@ class AstronomicalAdjustment:
 
         return i_sun * max(
             0,
-            cls.angle_sun_surface(time, day_number, latitude, longitude, utc_off),
+            cls.angle_sun_surface(
+                time, day_number, latitude, longitude, utc_off
+            ),
         )

--- a/data_preprocessing/main.py
+++ b/data_preprocessing/main.py
@@ -14,8 +14,8 @@ def main():
 
     df = pd.read_csv(RAW_CSV)
 
-    lat = 34.05
-    lon = 28.24
+    lat =  34.0522
+    lon = -118.2437
     utc = -8
 
     df[SOLAR_IRRADIANCE] = df.apply(


### PR DESCRIPTION
The astronomical adjustment has a *huge* effect on the output data. This means that if (for example) the offsets are wrong, it will zero out a large chunk of the data even if the data is there. There were a couple of typos and misplaced parentheses, and the longitude didn't match what was pulled by the other script. After fixing those, the distribution of radiations looked a lot more sane.